### PR TITLE
Fixed font-weight duplicated (Blog preview card)

### DIFF
--- a/blog-preview-card-main/style.css
+++ b/blog-preview-card-main/style.css
@@ -63,7 +63,6 @@ body {
 }
 .tag--learning {
     font-family: 'Text Preset 3', sans-serif;
-    font-weight: bold;
     font-size: 0.875rem;
     background-color: var(--yellow);
     padding: var(--spacing-50) var(--spacing-100);


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Remove duplicated font-weight from .tag--learning style